### PR TITLE
Add browsermock fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Usage
 -----
 
 ```javascript
+// use a mock DOM so we can run mithril on the server
+require('mithril/test-utils/browserMock')(global);
+
 var m = require('mithril');
 var render = require('mithril-node-render');
 


### PR DESCRIPTION
Adds the browsermock fix brought up in [this issue](https://github.com/MithrilJS/mithril.js/issues/1279) and [implemented in the isomorphic
example app](https://github.com/StephanHoyer/mithril-isomorphic-example/blob/master/server.js#L2). Based on [jsguy's comment](https://github.com/MithrilJS/mithril.js/issues/1279#issuecomment-283861044).

As far as I can tell, this is required to run this library with Mithril 1.0+, but it isn't mentioned anywhere explicitly in this repo. It might be useful to have it documented here.