### PR TITLE
Prevent destruction of class objects when cloning

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function removeEmpties (n) {
 
 function omit (source, keys) {
   keys = keys || []
-  var res = Object.create(source)
+  var res = Object.assign( Object.create( Object.getPrototypeOf(source)), source)
   keys.forEach(function(key) {
     if (key in res) { res[key] = null }
   });

--- a/index.js
+++ b/index.js
@@ -38,8 +38,8 @@ function removeEmpties (n) {
 }
 
 function omit (source, keys) {
-  var res = Object.create(source)
   keys = keys || []
+  var res = Object.create(source)
   keys.forEach(function(key) {
     if (key in res) { res[key] = null }
   });

--- a/index.js
+++ b/index.js
@@ -38,13 +38,12 @@ function removeEmpties (n) {
 }
 
 function omit (source, keys) {
+  var res = Object.create(source)
+  res.data = true;
   keys = keys || []
-  var res = {}
-  for (var k in source) {
-    if (keys.indexOf(k) < 0) {
-      res[k] = source[k]
-    }
-  }
+  keys.forEach(function(key) {
+    if (key in res) { res[key] = null }
+  });
   return res
 }
 

--- a/index.js
+++ b/index.js
@@ -39,7 +39,6 @@ function removeEmpties (n) {
 
 function omit (source, keys) {
   var res = Object.create(source)
-  res.data = true;
   keys = keys || []
   keys.forEach(function(key) {
     if (key in res) { res[key] = null }


### PR DESCRIPTION
The old omit method converts a class to a standard object instead of staying as a class, this prevents you from referencing other properties within the class