### PR TITLE
Make class component check match Mithril - fixes #77

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,11 +21,8 @@ function isFunction (thing) {
   return typeof thing === 'function'
 }
 
-function isClass(thing) {
-  return isFunction(thing) && (
-    /^\s*class\s/.test(thing.toString()) || // ES6 class
-    /^\s*_classCallCheck\(/.test(thing.toString().replace(/^[^{]+{/, '')) // Babel class
-  )
+function isClassComponent(thing) {
+  return thing.prototype != null && typeof thing.prototype.view === "function"
 }
 
 function camelToDash (str) {
@@ -123,7 +120,7 @@ function * createChildrenContent (view, options, hooks) {
 
 function * render (view, attrs, options) {
   options = options || {}
-  if (view.view || isClass(view)) { // root component
+  if (view.view || isFunction(view)) { // root component
     view = m(view, attrs)
   } else {
     options = attrs || {}
@@ -180,7 +177,7 @@ function * _render (view, options, hooks) {
     var component = view.view
     if (isObject(view.tag)) {
       component = view.tag
-    } else if (isClass(view.tag)) {
+    } else if (isClassComponent(view.tag)) {
       component = new view.tag(vnode)
     } else if (isFunction(view.tag)) {
       component = view.tag()

--- a/test.js
+++ b/test.js
@@ -8,6 +8,7 @@ var co = require('co')
 
 var ES6ClassComponent = require('./tests/fixtures/es6_class_component');
 var BabelClassComponent = require('./tests/fixtures/babel_class_component');
+var FunctionClassComponent = require('./tests/fixtures/function_class_component');
 
 o.async = function async (desc, genFn) {
   o(desc, function (done) {
@@ -132,7 +133,7 @@ o.spec('components', function () {
   })
 })
 
-var classComponents = { es6: ES6ClassComponent, babel: BabelClassComponent }
+var classComponents = { es6: ES6ClassComponent, babel: BabelClassComponent, function: FunctionClassComponent }
 for (var type in classComponents) {
   o.spec('component of ' + type + ' class', function () {
     var classComponent = classComponents[type];

--- a/tests/fixtures/function_class_component.js
+++ b/tests/fixtures/function_class_component.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const m = require('mithril/hyperscript')
+
+function ClassComponent(vnode) {
+  this.vnode = vnode
+}
+
+ClassComponent.prototype.oninit = function oninit() {
+  this.vnode.state.foo = 'bar'
+}
+
+ClassComponent.prototype.view = function view() {
+  return m('div', ['hello', this.vnode.state.foo, this.vnode.attrs.foo])
+}
+
+module.exports = ClassComponent;


### PR DESCRIPTION
I've added a function-style class component test to illustrate a type of class component that is allowed by Mithril but not allowed by the current `class`-only check.