### PR TITLE
Make mithril a peer dependency - fixes #76

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,12 @@
   },
   "homepage": "https://github.com/StephanHoyer/mithril-node-render",
   "dependencies": {
-    "co": "4.6.0",
-    "mithril": "1.1.3"
+    "co": "4.6.0"
+  },
+  "peerDependencies": {
+    "mithril": "^1.1.5"
+  },
+  "devDependencies": {
+    "mithril": "1.1.5"
   }
 }


### PR DESCRIPTION
Also bumps mithril from 1.1.3 to 1.1.5