### PR TITLE
Switch from co to async/await - fixes #78 (#81)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 sudo: false
 node_js:
-  - 4
-  - 5
-  - 6
+  - node
+  - 8

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const co = require('co')
 const m = require('mithril/hyperscript')
 
 const VOID_TAGS = ['area', 'base', 'br', 'col', 'command', 'embed', 'hr',
@@ -60,9 +59,9 @@ function escapeHtml (s, replaceDoubleQuote) {
   return s
 }
 
-function * setHooks (component, vnode, hooks) {
+async function setHooks (component, vnode, hooks) {
   if (component.oninit) {
-    yield component.oninit.call(vnode.state, vnode) || function * () {}
+    await component.oninit.call(vnode.state, vnode) || async function () {}
   }
   if (component.onremove) {
     hooks.push(component.onremove.bind(vnode.state, vnode))
@@ -106,17 +105,17 @@ function createAttrString (view, escapeAttributeValue) {
   }).join('')
 }
 
-function * createChildrenContent (view, options, hooks) {
+async function createChildrenContent (view, options, hooks) {
   if (view.text != null) {
     return options.escapeString(view.text)
   }
   if (isArray(view.children) && !view.children.length) {
     return ''
   }
-  return yield _render(view.children, options, hooks)
+  return _render(view.children, options, hooks)
 }
 
-function * render (view, attrs, options) {
+async function render (view, attrs, options) {
   options = options || {}
   if (view.view || isFunction(view)) { // root component
     view = m(view, attrs)
@@ -135,14 +134,14 @@ function * render (view, attrs, options) {
     if (!options.hasOwnProperty(key)) options[key] = defaultOptions[key]
   })
 
-  var result = yield _render(view, options, hooks)
+  var result = await _render(view, options, hooks)
 
   hooks.forEach(function (hook) { hook() })
 
   return result
 }
 
-function * _render (view, options, hooks) {
+async function _render (view, options, hooks) {
   var type = typeof view
 
   if (type === 'string') {
@@ -160,13 +159,13 @@ function * _render (view, options, hooks) {
   if (isArray(view)) {
     var result = ''
     for (const v of view) {
-      result += yield _render(v, options, hooks)
+      result += await _render(v, options, hooks)
     }
     return result
   }
 
   if (view.attrs) {
-    yield setHooks(view.attrs, view, hooks)
+    await setHooks(view.attrs, view, hooks)
   }
 
   // component
@@ -186,15 +185,15 @@ function * _render (view, options, hooks) {
       vnode.state = omit(component, COMPONENT_PROPS)
       vnode.attrs = component.attrs || view.attrs || {}
 
-      yield setHooks(component, vnode, hooks)
-      return yield _render(component.view.call(vnode.state, vnode), options, hooks)
+      await setHooks(component, vnode, hooks)
+      return _render(component.view.call(vnode.state, vnode), options, hooks)
     }
   }
 
   if (view.tag === '<') {
     return '' + view.children
   }
-  var children = yield createChildrenContent(view, options, hooks)
+  var children = await createChildrenContent(view, options, hooks)
   if (view.tag === '#') {
     return options.escapeString(children)
   }
@@ -211,5 +210,5 @@ function * _render (view, options, hooks) {
   ].join('')
 }
 
-module.exports = co.wrap(render)
+module.exports = render
 module.exports.escapeHtml = escapeHtml

--- a/test.js
+++ b/test.js
@@ -4,60 +4,61 @@ var o = require('mithril/ospec/ospec')
 var m = require('mithril/render/hyperscript')
 var mTrust = require('mithril/render/trust')
 var render = require('./index')
-var co = require('co')
 
 var ES6ClassComponent = require('./tests/fixtures/es6_class_component');
 var BabelClassComponent = require('./tests/fixtures/babel_class_component');
 var FunctionClassComponent = require('./tests/fixtures/function_class_component');
 
-o.async = function async (desc, genFn) {
-  o(desc, function (done) {
-    co(genFn).then(done)
+o.async = function (desc, asyncTest) {
+  o(desc, async function (done) {
+    await asyncTest()
+    done()
   })
 }
 
-o.async.only = function async (desc, genFn) {
-  o.only(desc, function (done) {
-    co(genFn).then(done)
+o.async = function (desc, asyncTest) {
+  o(desc, async function (done) {
+    await asyncTest()
+    done()
   })
 }
 
-o.async('render', function * () {
-  o(yield render(m('span', 'content'))).equals('<span>content</span>')('should render tag')
-  o(yield render(m('.foo', 'content'))).equals('<div class="foo">content</div>')('should render classname')
-  o(yield render(m('#bar', 'content'))).equals('<div id="bar">content</div>')('should render id')
-  o(yield render(m('br'))).equals('<br>')('should render short nodes when no children')
-  o(yield render(m('HR'))).equals('<HR>')('should render short nodes when no children and tag name is uppercase')
-  o(yield render(m('!doctype'))).equals('<!doctype>')('should render short node doctype')
-  o(yield render(m('!doctype', {html: true}))).equals('<!doctype html>')('should render short node doctype HTML5')
-  o(yield render(m('span', { 'data-foo': 'bar', selected: 'selected' }))).equals('<span data-foo="bar" selected="selected"></span>')('should render attributes')
-  o(yield render(m('ul', 'huhu'))).equals('<ul>huhu</ul>')('should render string')
-  o(yield render([m('span', 'foo'), m('div', 'bar')])).equals('<span>foo</span><div>bar</div>')('should render arrays')
-  o(yield render(m('div', [[m('span', 'foo'), m('div', 'bar')]]))).equals('<div><span>foo</span><div>bar</div></div>')('should render nested arrays')
-  o(yield render(m('span', m('div')))).equals('<span><div></div></span>')('should render children')
-  o(yield render(m('span', { onmousemove: function (event) {} }))).equals('<span></span>')('should not render events')
-  o(yield render(m('span', { style: { paddingLeft: '10px', color: 'red' } }))).equals('<span style="padding-left:10px;color:red"></span>')('should render children')
-  o(yield render(m('div', [ 1, m('span'), '2' ]))).equals('<div>1<span></span>2</div>')('should render numbers as text nodes')
-  o(yield render(m('div', 0))).equals('<div>0</div>')
-  o(yield render(m('div', false))).equals('<div></div>')
-  o(yield render(m('div', { a: true }))).equals('<div a></div>')
-  o(yield render(m('div', { a: false }))).equals('<div></div>')
-  o(yield render(m('div', { a: undefined }))).equals('<div></div>')
-  o(yield render(m('div', { style: null }))).equals('<div></div>')
-  o(yield render(m('div', { style: '' }))).equals('<div></div>')
-  o(yield render(m('div', { style: { color: '' } }))).equals('<div></div>')
-  o(yield render(m('div', { style: { height: '20px', color: '' } }))).equals('<div style="height:20px"></div>')
-  o(yield render(m('div', { style: { height: '20px', color: '', width: '10px' } }))).equals('<div style="height:20px;width:10px"></div>')
-  o(yield render(m('div', { a: 'foo' }))).equals('<div a="foo"></div>')
-  o(yield render(m('div', mTrust('<foo></foo>')))).equals('<div><foo></foo></div>')
-  o(yield render(m('div', '<foo></foo>'))).equals('<div>&lt;foo&gt;&lt;/foo&gt;</div>')
-  o(yield render(m('div', { style: '"></div><div a="' }))).equals('<div style="&quot;&gt;&lt;/div&gt;&lt;div a=&quot;"></div>')
-  o(yield render(m('div', { style: '"></div><div a="' }), { escapeAttributeValue: function (value) { return value } })).equals('<div style=""></div><div a=""></div>')
+o.async('render', async function () {
+  o(await render(m('span', 'content'))).equals('<span>content</span>')('should render tag')
+  o(await render(m('.foo', 'content'))).equals('<div class="foo">content</div>')('should render classname')
+  o(await render(m('#bar', 'content'))).equals('<div id="bar">content</div>')('should render id')
+  o(await render(m('br'))).equals('<br>')('should render short nodes when no children')
+  o(await render(m('HR'))).equals('<HR>')('should render short nodes when no children and tag name is uppercase')
+  o(await render(m('!doctype'))).equals('<!doctype>')('should render short node doctype')
+  o(await render(m('!doctype', {html: true}))).equals('<!doctype html>')('should render short node doctype HTML5')
+  o(await render(m('span', { 'data-foo': 'bar', selected: 'selected' }))).equals('<span data-foo="bar" selected="selected"></span>')('should render attributes')
+  o(await render(m('ul', 'huhu'))).equals('<ul>huhu</ul>')('should render string')
+  o(await render([m('span', 'foo'), m('div', 'bar')])).equals('<span>foo</span><div>bar</div>')('should render arrays')
+  o(await render(m('div', [[m('span', 'foo'), m('div', 'bar')]]))).equals('<div><span>foo</span><div>bar</div></div>')('should render nested arrays')
+  o(await render(m('span', m('div')))).equals('<span><div></div></span>')('should render children')
+  o(await render(m('span', { onmousemove: function (event) {} }))).equals('<span></span>')('should not render events')
+  o(await render(m('span', { style: { paddingLeft: '10px', color: 'red' } }))).equals('<span style="padding-left:10px;color:red"></span>')('should render children')
+  o(await render(m('div', [ 1, m('span'), '2' ]))).equals('<div>1<span></span>2</div>')('should render numbers as text nodes')
+  o(await render(m('div', 0))).equals('<div>0</div>')
+  o(await render(m('div', false))).equals('<div></div>')
+  o(await render(m('div', { a: true }))).equals('<div a></div>')
+  o(await render(m('div', { a: false }))).equals('<div></div>')
+  o(await render(m('div', { a: undefined }))).equals('<div></div>')
+  o(await render(m('div', { style: null }))).equals('<div></div>')
+  o(await render(m('div', { style: '' }))).equals('<div></div>')
+  o(await render(m('div', { style: { color: '' } }))).equals('<div></div>')
+  o(await render(m('div', { style: { height: '20px', color: '' } }))).equals('<div style="height:20px"></div>')
+  o(await render(m('div', { style: { height: '20px', color: '', width: '10px' } }))).equals('<div style="height:20px;width:10px"></div>')
+  o(await render(m('div', { a: 'foo' }))).equals('<div a="foo"></div>')
+  o(await render(m('div', mTrust('<foo></foo>')))).equals('<div><foo></foo></div>')
+  o(await render(m('div', '<foo></foo>'))).equals('<div>&lt;foo&gt;&lt;/foo&gt;</div>')
+  o(await render(m('div', { style: '"></div><div a="' }))).equals('<div style="&quot;&gt;&lt;/div&gt;&lt;div a=&quot;"></div>')
+  o(await render(m('div', { style: '"></div><div a="' }), { escapeAttributeValue: function (value) { return value } })).equals('<div style=""></div><div a=""></div>')
   o(typeof render.escapeHtml).equals('function')
-  o(yield render(m('pre', 'var = ' + JSON.stringify({foo: 1})))).equals('<pre>var = {"foo":1}</pre>')
-  o(yield render(m('svg', m('use', { href: 'fooga.com' })))).equals('<svg><use xlink:href="fooga.com"></use></svg>')
-  o(yield render(m('input'), {strict: true})).equals('<input/>')('should render closed input-tag')
-  o(yield render(m('div'), {strict: true})).equals('<div/>')('should render closed div-tag')
+  o(await render(m('pre', 'var = ' + JSON.stringify({foo: 1})))).equals('<pre>var = {"foo":1}</pre>')
+  o(await render(m('svg', m('use', { href: 'fooga.com' })))).equals('<svg><use xlink:href="fooga.com"></use></svg>')
+  o(await render(m('input'), {strict: true})).equals('<input/>')('should render closed input-tag')
+  o(await render(m('div'), {strict: true})).equals('<div/>')('should render closed div-tag')
 })
 
 o.spec('components', function () {
@@ -82,53 +83,53 @@ o.spec('components', function () {
     }
   })
 
-  o.async('embedded', function * () {
+  o.async('embedded', async function () {
     o(onremove.callCount).equals(0)
-    o(yield render(m('div', m(myComponent)))).equals('<div><div>hellobar</div></div>')
+    o(await render(m('div', m(myComponent)))).equals('<div><div>hellobar</div></div>')
     o(onremove.callCount).equals(1)
-    o(yield render(m('span', m(myComponent, {foo: 'foz'})))).equals('<span><div>hellobarfoz</div></span>')
-    o(yield render(m('div', m({
+    o(await render(m('span', m(myComponent, {foo: 'foz'})))).equals('<span><div>hellobarfoz</div></span>')
+    o(await render(m('div', m({
       oninit: function () {},
       view: function () {
         return m('span', 'huhu')
       }
     })))).equals('<div><span>huhu</span></div>')
-    o(yield render(m('div', m({
+    o(await render(m('div', m({
       view: function () {
         return m('span', 'huhu')
       }
     })))).equals('<div><span>huhu</span></div>')
   })
 
-  o.async('as root', function * () {
-    o(yield render(myComponent)).equals('<div>hellobar</div>')
-    o(yield render(myComponent, { foo: '-attr-foo' })).equals('<div>hellobar-attr-foo</div>')
+  o.async('as root', async function () {
+    o(await render(myComponent)).equals('<div>hellobar</div>')
+    o(await render(myComponent, { foo: '-attr-foo' })).equals('<div>hellobar-attr-foo</div>')
   })
 
-  o.async('with children', function * () {
+  o.async('with children', async function () {
     var parentComponent = {
       view: function (node) {
         return m('div', node.children)
       }
     }
 
-    o(yield render(m(parentComponent, 'howdy'))).equals('<div>howdy</div>')
-    o(yield render(m(parentComponent, m('span', 'howdy')))).equals('<div><span>howdy</span></div>')
-    o(yield render(m(parentComponent, [
+    o(await render(m(parentComponent, 'howdy'))).equals('<div>howdy</div>')
+    o(await render(m(parentComponent, m('span', 'howdy')))).equals('<div><span>howdy</span></div>')
+    o(await render(m(parentComponent, [
       m('span', 'foo'),
       m('span', 'bar')
     ]))).equals('<div><span>foo</span><span>bar</span></div>')
-    o(yield render(m(parentComponent, m.trust('<span>trust me</span>')))).equals('<div><span>trust me</span></div>')
-    o(yield render(m(parentComponent, m(myComponent, { foo: 'foz' })))).equals('<div><div>hellobarfoz</div></div>')
+    o(await render(m(parentComponent, m.trust('<span>trust me</span>')))).equals('<div><span>trust me</span></div>')
+    o(await render(m(parentComponent, m(myComponent, { foo: 'foz' })))).equals('<div><div>hellobarfoz</div></div>')
   })
 
-  o.async('quouting html content right', function * () {
+  o.async('quouting html content right', async function () {
     var component = {
       view: function (node) {
         return m('span', ['huh', '> >'])
       }
     }
-    var out = yield render(component)
+    var out = await render(component)
     o(out).equals('<span>huh&gt; &gt;</span>')
   })
 })
@@ -138,19 +139,19 @@ for (var type in classComponents) {
   o.spec('component of ' + type + ' class', function () {
     var classComponent = classComponents[type];
 
-    o.async('embedded', function * () {
-      o(yield render(m('div', m(classComponent)))).equals('<div><div>hellobar</div></div>')
-      o(yield render(m('span', m(classComponent, { foo: 'foz' })))).equals('<span><div>hellobarfoz</div></span>')
+    o.async('embedded', async function () {
+      o(await render(m('div', m(classComponent)))).equals('<div><div>hellobar</div></div>')
+      o(await render(m('span', m(classComponent, { foo: 'foz' })))).equals('<span><div>hellobarfoz</div></span>')
     })
 
-    o.async('as root', function * () {
-      o(yield render(classComponent)).equals('<div>hellobar</div>')
-      o(yield render(classComponent, { foo: '-attr-foo' })).equals('<div>hellobar-attr-foo</div>')
+    o.async('as root', async function () {
+      o(await render(classComponent)).equals('<div>hellobar</div>')
+      o(await render(classComponent, { foo: '-attr-foo' })).equals('<div>hellobar-attr-foo</div>')
     })
   })
 }
 
-o.async('`this` in component', function * () {
+o.async('`this` in component', async function () {
   var oninit = o.spy()
   var myComponent = {
     oninit: function (vnode) {
@@ -170,14 +171,14 @@ o.async('`this` in component', function * () {
     bar: 4
   }
 
-  o(yield render([m(myComponent), m(myComponent)])).equals('<div>hello</div><div>hello</div>')
+  o(await render([m(myComponent), m(myComponent)])).equals('<div>hello</div><div>hello</div>')
 
   o(oninit.callCount).equals(2)('the component should have been initialized twice')
 })
 
-o.async('lifecycle hooks as attributes on elements', function * () {
+o.async('lifecycle hooks as attributes on elements', async function () {
   var initialized, removed
-  yield render(m('p', {
+  await render(m('p', {
     oninit: function (vnode) {
       initialized = true
       o(this).equals(vnode.state)('vnode.state should be the context in `oninit`')
@@ -191,7 +192,7 @@ o.async('lifecycle hooks as attributes on elements', function * () {
   o(removed).equals(true)('attr.onremove should run')
 })
 
-o.async('lifecycle hooks as attributes on components', function * () {
+o.async('lifecycle hooks as attributes on components', async function () {
   var attrInitialized, attrRemoved, tagInitialized, tagRemoved
   var myComponent = {
     oninit: function () {
@@ -204,7 +205,7 @@ o.async('lifecycle hooks as attributes on components', function * () {
       tagRemoved = true
     }
   }
-  o(yield render(m(myComponent, {
+  o(await render(m(myComponent, {
     oninit: function (vnode) {
       o(this).equals(vnode.state)('vnode.state should be the context in `attr.oninit`')
       attrInitialized = true
@@ -218,7 +219,7 @@ o.async('lifecycle hooks as attributes on components', function * () {
   o(tagRemoved).equals(true)('tag.onremove should be called')
 })
 
-o.async('lifecycle hooks of class component', function * () {
+o.async('lifecycle hooks of class component', async function () {
   var initialized, removed
   var classComponent = class {
     constructor(vnode) {
@@ -240,12 +241,12 @@ o.async('lifecycle hooks of class component', function * () {
       return m('p', 'hello')
     }
   }
-  o(yield render(m(classComponent))).equals('<p>hello</p>')
+  o(await render(m(classComponent))).equals('<p>hello</p>')
   o(initialized).equals(true)('classComponent#oninit should run')
   o(removed).equals(true)('classComponent#onremove should run')
 })
 
-o.async('onremove hooks should be called once the whole tree has been inititalized', function * () {
+o.async('onremove hooks should be called once the whole tree has been inititalized', async function () {
   var initialized = 0
   var onremove = o.spy()
   function oninit () {
@@ -260,7 +261,7 @@ o.async('onremove hooks should be called once the whole tree has been inititaliz
     },
     onremove: onremove
   }
-  o(yield render([m(myComponent, attrs), m(myComponent, attrs)]))
+  o(await render([m(myComponent, attrs), m(myComponent, attrs)]))
 
   /*
   We just rendered two components, and each has three sets of hooks defined:
@@ -271,7 +272,7 @@ o.async('onremove hooks should be called once the whole tree has been inititaliz
   o(onremove.callCount).equals(6)('onremove should run six times')
 })
 
-o.async('hooks are called top-down, depth-first on elements', function * () {
+o.async('hooks are called top-down, depth-first on elements', async function () {
   /*
    Suppose a tree with the following structure: two levels of depth,
    two components on the first depth level, the first one having a
@@ -289,7 +290,7 @@ o.async('hooks are called top-down, depth-first on elements', function * () {
   var pRemoved = false
   var aRemoved = false
   var ulRemoved = false
-  var html = yield render([
+  var html = await render([
     m(
       'p',
       {
@@ -359,14 +360,14 @@ o.spec('async', function () {
     }
   })
 
-  o.async('render components', function * () {
-    const html = yield render(myAsyncComponent)
+  o.async('render components', async function () {
+    const html = await render(myAsyncComponent)
     o(html).equals('<div>bar</div>')
   })
 
-  o.async('render nodes', function * () {
+  o.async('render nodes', async function () {
     var oninitSpy = o.spy()
-    const html = yield render(m('span', {
+    const html = await render(m('span', {
       oninit: function (node) {
         return new Promise(resolve => {
           oninitSpy()
@@ -379,7 +380,7 @@ o.spec('async', function () {
   })
 })
 
-o.async('render closure components', function * () {
+o.async('render closure components', async function () {
   var closureComponent = function () {
     return {
       view: function(node) {
@@ -387,7 +388,7 @@ o.async('render closure components', function * () {
       }
     }
   }
-  o(yield render(closureComponent())).equals('<p>p</p>')
+  o(await render(closureComponent())).equals('<p>p</p>')
 })
 
 o.run()


### PR DESCRIPTION
* Switch from `co` to `async`/`await` - fixes #78

* Update node versions in Travis

Switching to `async`/`await` means that the library will no longer work (without transpiling) on any Node.js version <8.