### PR TITLE
Add mithril as a dev dependency for tests (Fix CI)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint-plugin-import": "2.8.0",
     "eslint-plugin-node": "5.2.1",
     "eslint-plugin-promise": "3.6.0",
-    "eslint-plugin-standard": "3.0.1"
+    "eslint-plugin-standard": "3.0.1",
+    "mithril": "^1.1.6"
   }
 }


### PR DESCRIPTION
My docs PR failed to pass CI, so I fixed CI. If there's a good reason you'd like to keep mithril out of the dev dependencies, we could add something to the TravisCI config with a comment explaining why.